### PR TITLE
Release 0.2.0

### DIFF
--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.1.0.pre"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Release 0.2.0 includes:

Suppressing **Missing top-level class documentation** warning.
```ruby
Documentation:
  Enabled: false
```

Prefer parentheses to brackets or curly brackets for percent literals.
```ruby
Style/PercentLiteralDelimiters:
  PreferredDelimiters:
    '%i': ()
    '%I': ()
    '%q': ()
    '%Q': ()
    '%r': '{}'
    '%s': ()
    '%w': ()
    '%W': ()
    '%x': ()
```

Prefer that access modifiers (`private` and `protected`) be outdented (at the same level as `class`)
```ruby
Layout/AccessModifierIndentation:
  EnforcedStyle: outdent
```