### PR TITLE
Prefer alias_method over alias

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -7,6 +7,9 @@ Layout/AccessModifierIndentation:
 Metrics/LineLength:
   Max: 100
 
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': ()


### PR DESCRIPTION
```ruby
alias_method :new_name, :old_name

# vs

alias new_name old_name
```

`alias` does weird things (like not work right in certain scopes) because it it a magic keyword.

`alias_method` always works as expected because it is just a simple method call.