### PR TITLE
updated path for .rubocop.yml

### DIFF
--- a/lib/generators/ramsey_cop_generator.rb
+++ b/lib/generators/ramsey_cop_generator.rb
@@ -1,9 +1,7 @@
 class RamseyCopGenerator < Rails::Generators::Base
-
   source_root(File.expand_path(File.dirname(__FILE__)))
 
   def create_rubcop_yml
-    template 'rscop.yml', 'config/.rubocop.yml'
+    template "rscop.yml", ".rubocop.yml"
   end
-
 end


### PR DESCRIPTION
Noticed I was having issues by having the the rubocop.yml  in the config, so I moved it out. I also made comply with our standards.