### PR TITLE
Metrics/LineLength: set Max: 120

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -5,7 +5,7 @@ Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
 Metrics/LineLength:
-  Max: 100
+  Max: 120
 
 Style/Alias:
   EnforcedStyle: prefer_alias_method


### PR DESCRIPTION
It just feels cramped at 100.

Note: 100 is already expanded, the base rubocop default is **80** characters.