### PR TITLE
Style/SignalException: set EnforcedStyle: semantic

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -53,6 +53,9 @@ Style/PercentLiteralDelimiters:
     '%W': ()
     '%x': ()
 
+Style/SignalException:
+  EnforcedStyle: semantic
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
   Enabled: true


### PR DESCRIPTION
I really like to be able to say

```ruby
def a
  fail SomeError if error_condition? #=> more obviously a failure than a similar "raise" would be
end

def b
  a
rescue
  puts $!.message
  raise # => re-"raise" last exception
end

```