### PR TITLE
Style/EachWithObject: set Enabled: false

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -10,6 +10,9 @@ Metrics/LineLength:
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 
+Style/EachWithObject:
+  Enabled: false
+
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%i': ()


### PR DESCRIPTION
I had:
```ruby
  def contiguous_date_ranges
    relevant_calculated_dates.reduce([]) do |ranges, date|
      #  ... some logic ...
      ranges
    end
  end
```

this cop forces:
```ruby
    def contiguous_date_ranges
      relevant_calculated_dates.each_with_object([]) do |date, ranges|
        #  ... some logic ...
      end
    end
```