### PR TITLE
Update the generator to simply copy the default.yml file to .rubocop.yml

### DIFF
--- a/documentation/existing-repositories.md
+++ b/documentation/existing-repositories.md
@@ -4,14 +4,7 @@ Here are a few tips for introducing RamseyCop to an existing project
 
 * Delete any existing `.rubocop.yml` config files
 * Run `rails generate ramsey_cop`
-  * Or manually create a new `.rubocop.yml` that contains only
-
-```yaml
-inherit_gem:
-  ramsey_cop:
-    - default.yml
-```
-
+  * Currently this will just copy `default.yml` to `.rubocop.yml`. Once this RamseyCop is available via RubyGems, we can go back to inheriting from `default.yml` instead.
 ## Getting a feel for the current state of your code.
 * Run `bundle exec rubocop -f o` to get a count of violations per cop.
 * Run `bundle exec rubocop -f w` to see your worst offending files.

--- a/lib/generators/ramsey_cop_generator.rb
+++ b/lib/generators/ramsey_cop_generator.rb
@@ -2,6 +2,6 @@ class RamseyCopGenerator < Rails::Generators::Base
   source_root(File.expand_path(File.dirname(__FILE__)))
 
   def create_rubcop_yml
-    template "rscop.yml", ".rubocop.yml"
+    template "../../default.yml", ".rubocop.yml"
   end
 end

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end


### PR DESCRIPTION
With this gem currently being available only internally, CodeClimate
is unable to pull it in. This means we cannot inherit from this gem.

This changes allows us to still get the benefits of a shared rubocop
in the meantime config.