### PR TITLE
Disable Style/Lambda

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -38,6 +38,9 @@ Style/Alias:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+Style/Lambda:
+  Enabled: false
+
 Style/NumericLiterals:
   Enabled: false
 


### PR DESCRIPTION
Currently, we are being forced to do weird stuff with scopes:

```ruby
scope(
  :some_name,
  lambda do
    foo
    bar
    baz
  end
)
```

I want to disable the cop so I can do:

```ruby
scope :some_name, -> {
  foo
  bar
  baz
}
```