### PR TITLE
Style/DateTime: set Enabled: false

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -38,6 +38,9 @@ Style/Alias:
 Style/AndOr:
   EnforcedStyle: conditionals
 
+Style/DateTime:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
When enabled, this shows an error when you use `DateTime` and suggests `Date` or `Time` instead.

Given that we are a rails show, using DateTime is going to be pretty important.