### PR TITLE
Performance/FixedSize: set Enabled: false

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -32,6 +32,9 @@ Metrics/MethodLength:
     - spec/**/*
     - test/**/*
 
+Performance/FixedSize:
+  Enabled: false
+
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 


### PR DESCRIPTION
Currently:

```ruby
def foo_length
  "foo".length #=> rubocop error
end
```

Notably this does *not* error when done on a const:

```ruby
FOO_LENGTH = "foo".length #=> totally fine
```

Thoughts? This is kind of convenient for some kinds of parsing/meta-programming.