### PR TITLE
Style/RegexpLiteral: use inner and outer slashes

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -62,6 +62,9 @@ Style/PercentLiteralDelimiters:
     '%W': ()
     '%x': ()
 
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
   Enabled: true


### PR DESCRIPTION
The current behavior will require `%r{}` syntax, but only if there are inner slashes in the regex.

This looks odd when two regexes are close together, but only one has slashes:
```ruby
stub_request(
  :post,
  %r{convoso.+leads\/insert\z}
).with(
  body: /auth_token=\w+&list_id=11111&phone_number=8888675309&email=elptest%40daveramsey.com\z/
)
```

This PR allows me to write:
```ruby
stub_request(
  :post,
  /convoso.+leads\/insert\z/
).with(
  body: /auth_token=\w+&list_id=11111&phone_number=8888675309&email=elptest%40daveramsey.com\z/
)
```