### PR TITLE
Bump rubocop to latest

### DIFF
--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.50"
+  spec.add_dependency "rubocop", "~> 0.52.1"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/releases/tag/v0.51.0
https://github.com/bbatsov/rubocop/releases/tag/v0.52.0
and
https://github.com/bbatsov/rubocop/releases/tag/v0.52.1

I just picked out a couple of changes that looked interesting.

Layout/ClassStructure - disabled by default, but something I might try.
https://github.com/bbatsov/rubocop/pull/5065

Style/StringHashKeys
https://github.com/bbatsov/rubocop/issues/4650

Everyone OK with rolling this up with the PR from @jwsloan? @lampo/ruby-on-rails-chapter 