### PR TITLE
Style/RegexpLiteral: set Enabled: false

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -62,10 +62,6 @@ Style/PercentLiteralDelimiters:
     '%W': ()
     '%x': ()
 
-Style/RegexpLiteral:
-  EnforcedStyle: mixed
-  AllowInnerSlashes: true
-
 Style/StringLiterals:
   EnforcedStyle: double_quotes
   Enabled: true


### PR DESCRIPTION
Based on the [docs](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RegexpLiteral) for this rule, we misunderstood what `mixed` was meant to do.

I don't think there is a good way to keep this rule enabled, so we will just have to rely on developer discretion.