### PR TITLE
AllCops Exclude: db/schema.rb (as a generated file)

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - "db/schema.rb"
+
 Documentation:
   Enabled: false
 


### PR DESCRIPTION
It doesn't make sense for rubocop to inspect this file since we just check in the auto-generated version.
