### PR TITLE
PLAT-1379 RuboCop 0.53.0 has been released

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ramsey_cop (0.7.3)
-      rubocop (~> 0.52.1)
+      rubocop (~> 0.53.0)
 
 GEM
   remote: https://rubygems.org/
@@ -10,7 +10,7 @@ GEM
     ast (2.4.0)
     diff-lcs (1.3)
     parallel (1.12.1)
-    parser (2.5.0.0)
+    parser (2.5.0.4)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rainbow (3.0.0)
@@ -28,9 +28,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (0.52.1)
+    rubocop (0.53.0)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.52.1"
+  spec.add_dependency "rubocop", "~> 0.53.0"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
## Description of Proposed Changes
https://github.com/bbatsov/rubocop/releases/tag/v0.53.0

Follow Rubocop Latest Release