### PR TITLE
Bump rubocop dependency to 0.54.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ramsey_cop (0.7.3)
-      rubocop (~> 0.53.0)
+      rubocop (~> 0.54.0)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rubocop (0.53.0)
+    rubocop (0.54.0)
       parallel (~> 1.10)
       parser (>= 2.5)
       powerpack (~> 0.1)

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.53.0"
+  spec.add_dependency "rubocop", "~> 0.54.0"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
@jwsloan I'd like to slide one more bump in and then get that 0.8.0 out.

Release Notes for 0.54.0 https://github.com/bbatsov/rubocop/releases/tag/v0.54.0

Most interesting bit

[#5597](https://github.com/bbatsov/rubocop/pull/5597): Add new Rails/HttpStatus cop. I like this 👍 