### PR TITLE
Metrics/BlockLength: Exclude rake files

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -18,6 +18,7 @@ Metrics/BlockLength:
     - spec/**/*
     - test/**/*
     - "*.gemspec"
+    - "**/*.rake"
 
 Metrics/BlockNesting:
   Exclude:


### PR DESCRIPTION
I want to be able to have arbitrarily large `namespace` blocks.