### PR TITLE
suggested changes from fpu-online

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
-    - "db/schema.rb"
+    - db/schema.rb
+    - vendor/**/*
 
 Documentation:
   Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -42,6 +42,11 @@ Metrics/MethodLength:
     - spec/**/*
     - test/**/*
 
+Metrics/ModuleLength:
+  Exclude:
+    - spec/**/*
+    - test/**/*
+
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 

--- a/default.yml
+++ b/default.yml
@@ -16,6 +16,9 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Exclude:
+    - config/initializers/*
+    - config/routes.rb
+    - Gemfile
     - spec/**/*
     - test/**/*
     - "*.gemspec"

--- a/default.yml
+++ b/default.yml
@@ -39,6 +39,7 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Exclude:
+    - db/migrate/*
     - spec/**/*
     - test/**/*
 

--- a/default.yml
+++ b/default.yml
@@ -36,6 +36,10 @@ Metrics/CyclomaticComplexity:
 
 Metrics/LineLength:
   Max: 120
+  Exclude:
+    - config/routes.rb
+    - config/routes/*
+    - db/migrate/*
 
 Metrics/MethodLength:
   Exclude:


### PR DESCRIPTION
## Description of Proposed Changes
These changes encompass the global overrides that have recently been accepted as part of a recent cleanup in FPU: https://github.com/lampo/fpu-online/pull/1440. We realize that these changes could be nice for other teams/repos as well, so we're recommending them for consideration here.

While we normally don't spend time on style-only changes, the FPU team has recently added automated code quality enforcement to remove the pain point of manual enforcement during code reviews.

I wanted to make sure we had a good understanding of how much this change would affect us in adjusting our programming habits, so I worked through all of the offenses in our repo. In addition to the easy automatic corrections, I corrected most of the offenses, silenced a few pieces of dense "legacy" code (in place to prompt later cleanup when one of us has established better context), and noticed a few offending patterns that we decided were acceptable to our team.

This PR includes those global configuration changes. (I also made a couple size limit bumps within our `app/controllers`, but don't see a clean, easy way to distribute those settings from here.)

## Related Issue (if applicable)
_n/a_

## Your Testing Procedure
Before starting this change, I already had my FPU repo passing `rubocop`. I moved the FPU configuration changes here (eliminating the accompanying merges I needed there), pointed my Gemfile here, and made sure the repo still passed `rubocop`.

## Types of Changes
- global configuration changes


## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
- [X] The [CONTRIBUTING](CONTRIBUTING.md) document was read and followed.
- [X] All new and existing tests pass.
