### PR TITLE
Release ramsey_cop 0.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.11.0)
+    ramsey_cop (0.12.0)
       rubocop (>= 0.54, < 0.61)
 
 GEM
@@ -11,7 +11,7 @@ GEM
     diff-lcs (1.3)
     jaro_winkler (1.5.1)
     parallel (1.12.1)
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
@@ -22,7 +22,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.11.0".freeze
+  VERSION = "0.12.0".freeze
 end


### PR DESCRIPTION
Release support for rubocop 0.60.0
https://github.com/rubocop-hq/rubocop/releases/tag/v0.60.0

A team member reported local dev issues in VS Code with rubocop 0.59.2. This may or may not help, but we might as well attempt to stay current.