### PR TITLE
fix: Update rubocop dependecy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.13.0)
-      rubocop (~> 0)
+    ramsey_cop (0.13.1)
+      rubocop (~> 0.62.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
     diff-lcs (1.3)
-    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.2)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.13.0".freeze
+  VERSION = "0.13.1".freeze
 end

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0"
+  spec.add_dependency "rubocop", "~> 0.62.0"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
We found a potential security vulnerability in a repository for which
you have been granted security alert access.

@RamseyInHouse  RamseyInHouse/ramsey-cop
Known low severity security vulnerability detected in rubocop < 0.48.1
defined in ramsey_cop.gemspec.
ramsey_cop.gemspec update suggested: rubocop ~> 0.49.0.
Always verify the validity and compatibility of suggestions with your
codebase.