### PR TITLE
Relax rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ramsey_cop (0.13.1)
-      rubocop (~> 0.62.0)
+      rubocop (~> 0.62)
 
 GEM
   remote: https://rubygems.org/
@@ -10,10 +10,10 @@ GEM
     ast (2.4.0)
     diff-lcs (1.3)
     jaro_winkler (1.5.2)
-    parallel (1.12.1)
-    parser (2.5.3.0)
+    parallel (1.16.0)
+    parser (2.6.2.0)
       ast (~> 2.4.0)
-    powerpack (0.1.2)
+    psych (3.1.0)
     rainbow (3.0.0)
     rake (12.3.2)
     rspec (3.8.0)
@@ -29,16 +29,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.62.0)
+    rubocop (0.66.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
+      unicode-display_width (>= 1.4.0, < 1.6)
     ruby-progressbar (1.10.0)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.5.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.13.1)
+    ramsey_cop (0.13.2)
       rubocop (~> 0.62)
 
 GEM

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.13.1".freeze
+  VERSION = "0.13.2".freeze
 end

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.62.0"
+  spec.add_dependency "rubocop", "~> 0.62"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
## Description of Proposed Changes

The previous commit changed the rubocop lock from a nonexistent `~> 0` to a much more restrictive `~> 0.62.0`. This change will allow for future < 1.0 rubocop updates.

## Your Testing Procedure

I pointed smartdollar-app to my local repo, updated rubocop to 0.66, and ran it to verify it was still complaining about older code as expected.

## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
- [ ] The [CONTRIBUTING](CONTRIBUTING.md) document was read and followed.
- [X] All new and existing tests pass.
