### PR TITLE
Update rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.13.2)
+    ramsey_cop (0.14.0)
       rubocop (~> 0.62)
       rubocop-performance
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ramsey_cop (0.13.2)
       rubocop (~> 0.62)
+      rubocop-performance
 
 GEM
   remote: https://rubygems.org/
@@ -10,10 +11,9 @@ GEM
     ast (2.4.0)
     diff-lcs (1.3)
     jaro_winkler (1.5.2)
-    parallel (1.16.0)
-    parser (2.6.2.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
-    psych (3.1.0)
     rainbow (3.0.0)
     rake (12.3.2)
     rspec (3.8.0)
@@ -22,21 +22,22 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.66.0)
+    rubocop (0.68.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
-      psych (>= 3.1.0)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     ruby-progressbar (1.10.0)
     unicode-display_width (1.5.0)
 
@@ -50,4 +51,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/default.yml
+++ b/default.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   Exclude:
     - db/schema.rb

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.13.2".freeze
+  VERSION = "0.14.0".freeze
 end

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "ramsey_cop/version"
 
@@ -13,13 +13,14 @@ Gem::Specification.new do |spec|
   spec.license       = "GPLv3"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(/^(test|spec|features)\//)
+    f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(/^exe\//) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 0.62"
+  spec.add_dependency "rubocop-performance"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
rubocop is warning that performance cops are being moved to the
rubocop-performance gem. This brings that in, and moves to the latest
rubocop.