### PR TITLE
Ignore node_modules folder

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - db/schema.rb
     - vendor/**/*
+    - node_modules/**/*
 
 Documentation:
   Enabled: false

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.14.0".freeze
+  VERSION = "0.14.1".freeze
 end


### PR DESCRIPTION
Rubocop should not parse anything in the node_modules folder.