### PR TITLE
Enable new Style/Hash* cops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.16.0)
+    ramsey_cop (0.17.0)
       rubocop (~> 0.62)
       rubocop-performance
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,11 @@ GEM
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.0.1)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (12.3.3)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -29,17 +30,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.79.0)
+    rubocop (0.80.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby

--- a/default.yml
+++ b/default.yml
@@ -67,6 +67,15 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Style/Lambda:
   Enabled: false
 

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.16.0".freeze
+  VERSION = "0.17.0".freeze
 end


### PR DESCRIPTION
## Description of Proposed Changes

This change enables the Style/Hash* cops added with Rubocop 0.80.

The big question is: are these new defaults acceptable to Ramsey senior devs, or do you have a case for another deviation from Rubocop's default style guide?

## Related Issue (if applicable)

_n/a_

## Your Testing Procedure

I've enabled these new cops in a couple of my own (i.e. non-Ramsey) repos and don't have any complaints.


## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
