### PR TITLE
Enable new Lint cops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.18.0)
-      rubocop (>= 0.80.1)
+    ramsey_cop (0.19.0)
+      rubocop (>= 0.81)
       rubocop-performance (>= 1.5.2)
 
 GEM
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.0.4)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (12.3.3)
@@ -30,18 +30,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby

--- a/default.yml
+++ b/default.yml
@@ -16,6 +16,12 @@ Layout/LineLength:
     - config/routes/*
     - db/migrate/*
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/AbcSize:
   Exclude:
     - spec/**/*

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.18.0".freeze
+  VERSION = "0.19.0".freeze
 end

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.80.1"
+  spec.add_dependency "rubocop", ">= 0.81"
   spec.add_dependency "rubocop-performance", ">= 1.5.2"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
## Description of Proposed Changes
This change enables the new Lint cops added with Rubocop 0.81.

This also assumes the defaults are the desired approach for the codeowners of this repo.  Please let me know if one of them should not be enabled or something else set differently.

## Related Issue (if applicable)
n/a

## Your Testing Procedure
I enabled this in a few of my own repos and had no issues.

## Types of Changes
(e.g. bug fix, new feature, breaking change, etc.)
Enabled new cops due to the new version of Rubocop per the recommendation of [their documentation here](https://docs.rubocop.org/en/latest/versioning/).

## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
- [x] The [CONTRIBUTING](CONTRIBUTING.md) document was read and followed.
- [x] All new and existing tests pass.
