### PR TITLE
Bump rubocop from 0.81.0 to 0.82.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.19.0)
-      rubocop (>= 0.81)
+    ramsey_cop (0.20.0)
+      rubocop (>= 0.82)
       rubocop-performance (>= 1.5.2)
 
 GEM
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.3)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.1.0)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rake (12.3.3)
@@ -30,7 +30,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.81.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)

--- a/default.yml
+++ b/default.yml
@@ -19,6 +19,9 @@ Layout/LineLength:
 Lint/RaiseException:
   Enabled: true
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+
 Lint/StructNewOverride:
   Enabled: true
 
@@ -68,6 +71,9 @@ Style/DateTime:
   Enabled: false
 
 Style/Documentation:
+  Enabled: false
+
+Style/ExponentialNotation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.19.0".freeze
+  VERSION = "0.20.0".freeze
 end

--- a/ramsey_cop.gemspec
+++ b/ramsey_cop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", ">= 0.81"
+  spec.add_dependency "rubocop", ">= 0.82"
   spec.add_dependency "rubocop-performance", ">= 1.5.2"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
## Description of Proposed Changes

Bump version and add definitions for new non-default cops

## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
- [x] The [CONTRIBUTING](CONTRIBUTING.md) document was read and followed.
- [x] All new and existing tests pass.
