### PR TITLE
Layout/EmptyLinesAroundAttributeAccessor: Enabled: true

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -10,7 +10,7 @@ Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
 Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: false
+  Enabled: true
 
 Layout/LineLength:
   Max: 120
@@ -22,6 +22,7 @@ Layout/LineLength:
 Lint/RaiseException:
   Enabled: true
 
+# TODO: Review this rule!
 Layout/SpaceAroundMethodCallOperator:
   Enabled: false
 
@@ -76,6 +77,7 @@ Style/DateTime:
 Style/Documentation:
   Enabled: false
 
+# TODO: Review this rule!
 Style/ExponentialNotation:
   Enabled: false
 
@@ -109,6 +111,7 @@ Style/PercentLiteralDelimiters:
     '%W': ()
     '%x': ()
 
+# TODO: Review this rule!
 Style/SlicingWithRange:
   Enabled: false
 


### PR DESCRIPTION
In general, I think grouping similar macros is a good idea, and having spaces between most macros and methods makes sense.

[Source documentation](https://docs.rubocop.org/en/stable/cops_layout/#layoutemptylinesaroundattributeaccessor)

```ruby
# bad
attr_accessor :foo
def do_something
end

# good
attr_accessor :foo

def do_something
end

# good
attr_accessor :foo
attr_reader :bar
attr_writer :baz
attr :qux

def do_something
end
```