### PR TITLE
Layout/SpaceAroundMethodCallOperator: Enabled: true

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -23,7 +23,7 @@ Lint/RaiseException:
   Enabled: true
 
 Layout/SpaceAroundMethodCallOperator:
-  Enabled: false
+  Enabled: true
 
 Lint/StructNewOverride:
   Enabled: true


### PR DESCRIPTION
Yeah, I find it very hard to read with spaces. Wouldn't have thought this needed a rule, but better to be explicit

[Source Documentation](https://docs.rubocop.org/en/stable/cops_layout/#layoutspacearoundmethodcalloperator)

```ruby
# bad
foo. bar
foo .bar
foo . bar
foo. bar .buzz
foo
  . bar
  . buzz
foo&. bar
foo &.bar
foo &. bar
foo &. bar&. buzz
RuboCop:: Cop
RuboCop:: Cop:: Cop
:: RuboCop::Cop

# good
foo.bar
foo.bar.buzz
foo
  .bar
  .buzz
foo&.bar
foo&.bar&.buzz
RuboCop::Cop
RuboCop::Cop::Cop
::RuboCop::Cop
```