### PR TITLE
Style/ExponentialNotation: Enabled: true

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -77,7 +77,7 @@ Style/Documentation:
   Enabled: false
 
 Style/ExponentialNotation:
-  Enabled: false
+  Enabled: true
 
 Style/FrozenStringLiteralComment:
   Enabled: false


### PR DESCRIPTION
This makes sense to me, but I am curious to see what others think. I basically never use these literals.

[Source Documentation](https://docs.rubocop.org/en/latest/cops_style/#styleexponentialnotation)

```ruby
# Enforces a mantissa between 1 (inclusive) and 10 (exclusive).

# bad
10e6
0.3e4
11.7e5
3.14e0

# good
1e7
3e3
1.17e6
3.14
```