### PR TITLE
Style/SlicingWithRange: Enabled: true

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -110,7 +110,7 @@ Style/PercentLiteralDelimiters:
     '%x': ()
 
 Style/SlicingWithRange:
-  Enabled: false
+  Enabled: true
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
This is nice in that it trains people to use the new endless range feature I guess, but breaking that muscle memory will be hard.

[Source documentation](https://docs.rubocop.org/en/latest/cops_style/#styleslicingwithrange)

```ruby
# bad
items[1..-1]

# good
items[1..]
```