### PR TITLE
Set default for NewCops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.22.0)
+    ramsey_cop (0.23.0)
       rubocop (>= 0.82)
       rubocop-performance (>= 1.5.2)
 

--- a/default.yml
+++ b/default.yml
@@ -5,6 +5,7 @@ AllCops:
     - db/schema.rb
     - vendor/**/*
     - node_modules/**/*
+  NewCops: disable
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.22.0".freeze
+  VERSION = "0.23.0".freeze
 end

--- a/spec/ramsey_cop_spec.rb
+++ b/spec/ramsey_cop_spec.rb
@@ -1,7 +1,12 @@
 require "spec_helper"
+require "rubocop"
 
 RSpec.describe RamseyCop do
   it "has a version number" do
     expect(RamseyCop::VERSION).not_to be nil
+  end
+
+  it "has a valid config" do
+    expect { RuboCop::ConfigLoader.load_file("./default.yml") }.to_not raise_error
   end
 end


### PR DESCRIPTION
## Description of Proposed Changes
* Adding a default for `NewCops`
* Adding a test for checking the validity of the `default.yml` file

## Related Issue (if applicable)
This effectively fixes the warning when NewCops are added:
https://rubocop.readthedocs.io/en/latest/versioning/#pending-cops

Setting it to "disable" is probably the least disruptive, but if we want to set it to `enable` I'm ok with that too.  I mainly want it set to suppress the warning.

Take a look at the above doc link.  I believe that when a `cop` moves beyond the `new` status, rubocop will set the default one way or the other, then the `NewCop` setting no longer applies.  I think of this as... set it to `enabled` if you want to be on the bleeding edge of new cops, `disabled` if not.

## Your Testing Procedure


## Types of Changes
(e.g. bug fix, new feature, breaking change, etc.)


## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
- [ ] The [CONTRIBUTING](CONTRIBUTING.md) document was read and followed.
- [ ] All new and existing tests pass.
