### PR TITLE
Hashes and arrays as one line

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,21 @@
 PATH
   remote: .
   specs:
-    ramsey_cop (0.23.0)
+    ramsey_cop (0.24.0)
       rubocop (>= 0.82)
       rubocop-performance (>= 1.5.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.0)
+    ast (2.4.1)
     diff-lcs (1.3)
-    parallel (1.19.1)
-    parser (2.7.1.2)
-      ast (~> 2.4.0)
+    parallel (1.20.1)
+    parser (2.7.2.0)
+      ast (~> 2.4.1)
     rainbow (3.0.0)
     rake (12.3.3)
+    regexp_parser (2.0.0)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -29,15 +30,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.83.0)
+    rubocop (1.6.1)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-performance (1.5.2)
-      rubocop (>= 0.71.0)
+    rubocop-ast (1.3.0)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.9.1)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.10.1)
     unicode-display_width (1.7.0)
 

--- a/default.yml
+++ b/default.yml
@@ -59,6 +59,10 @@ Metrics/MethodLength:
     - db/migrate/*
     - spec/**/*
     - test/**/*
+  CountAsOne:
+    - hash
+    - array
+    - heredoc
 
 Metrics/ModuleLength:
   Exclude:

--- a/lib/ramsey_cop/version.rb
+++ b/lib/ramsey_cop/version.rb
@@ -1,3 +1,3 @@
 module RamseyCop
-  VERSION = "0.23.0".freeze
+  VERSION = "0.24.0".freeze
 end


### PR DESCRIPTION
## Description of Proposed Changes
Allow hashes, arrays, and heredocs to only count as one line of a method no matter how many actual lines they span.


## Related Issue (if applicable)


## Your Testing Procedure


## Types of Changes
(e.g. bug fix, new feature, breaking change, etc.)


## Check All that Apply
- [ ] These changes require an update to the documentation.
- [ ] Updates to the documentation have been made.
- [ ] The [CONTRIBUTING](CONTRIBUTING.md) document was read and followed.
- [ ] All new and existing tests pass.
